### PR TITLE
Revert "chore(deps): update etherpad/etherpad docker tag to v2.2.6"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM etherpad/etherpad:2.2.6
+FROM etherpad/etherpad:2.1.1
 
 ARG ETHERPAD_PLUGINS="ep_sticky_attributes ep_themes"
 


### PR DESCRIPTION
Reverts mynaparrot/plugNmeet-etherpad#35 because not working with `ep_themes`